### PR TITLE
size_or_version の文字列幅が正しく設定されない問題を修正

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -121,17 +121,17 @@ end
 
 # 文字列幅調整が必要な項目ごとの文字列長リスト
 def update_max_length_list(file_attr, max_length_list)
-  {
+  list = {
     hard_link: [max_length_list[:hard_link], file_attr[:hard_link].length].max,
     user: [max_length_list[:user], file_attr[:user].length].max,
     group: [max_length_list[:group], file_attr[:group].length].max,
     major: device?(file_attr[:type]) ? [max_length_list[:major], file_attr[:major].length].max : max_length_list[:major],
     minor: device?(file_attr[:type]) ? [max_length_list[:minor], file_attr[:minor].length].max : max_length_list[:minor],
-    size: !device?(file_attr[:type]) ? [max_length_list[:size], file_attr[:size].length].max : max_length_list[:size],
-
-    # メジャー/マイナーの場合は " ," で連結されるためオフセットを含めて判定する
-    size_or_version: [max_length_list[:size], max_length_list[:major] + max_length_list[:minor] + DEVICE_DISPLAY_OFFSET].max
+    size: !device?(file_attr[:type]) ? [max_length_list[:size], file_attr[:size].length].max : max_length_list[:size]
   }
+  # メジャー/マイナーの場合は " ," で連結されるためオフセットを含めて判定する
+  list[:size_or_version] = [list[:size], list[:major] + list[:minor] + DEVICE_DISPLAY_OFFSET].max
+  list
 end
 
 def file_attribute_hash(file, file_stat, full_path, max_length_list)


### PR DESCRIPTION
# 概要

size_or_version の文字列幅が正しく設定されない問題を修正
※この問題は「読み込んだ最終ファイルの該当カラムの文字列幅が最も長い」といった条件で確認されます。

# 詳細

[-l]オプションが指定された場合の、各カラム毎の文字列の最大幅を決定する`update_max_length_list`メソッドにおいて、「size_or_version」の値が正しくない問題を修正しました。

## 発生原因
メソッド内の最終行で下記処理を行っていますが、ここで`max_length_list`を用いてHashに追加しています。
`size_or_version: [max_length_list[:size], max_length_list[:major] + max_length_list[:minor] + DEVICE_DISPLAY_OFFSET].max`

しかし、`max_length_list`は「前回までの結果」が入っているものに過ぎないため、もし最終ファイルのカラムの文字列幅が最も長い場合、その結果が反映されず2番目に長いカラムの幅が設定され、全体の表記にずれが生じます。

実装中に気づかなかったのは、偶然途中のファイルの文字列幅が最も長かった為、正しく設定されているように見えていたためでした。

## 対応内容

一度`list`へ格納し、今回の各カラムに対する結果が確定後、改めて`size_or_version`の値を設定するようにしました。